### PR TITLE
Use major version from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Electron ChromeDriver
 
-[![Linux Build Status](https://travis-ci.org/kevinsawicki/electron-chromedriver.svg?branch=master)](https://travis-ci.org/kevinsawicki/electron-chromedriver)
+[![Linux Build Status](https://travis-ci.org/electron/chromedriver.svg?branch=master)](https://travis-ci.org/kevinsawicki/electron-chromedriver)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/wg4lulcyqid86d7f/branch/master?svg=true)](https://ci.appveyor.com/project/kevinsawicki/electron-chromedriver/branch/master)
 <br>
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -4,10 +4,12 @@ var mkdirp = require('mkdirp')
 var path = require('path')
 var request = require('request')
 
+var versionSegments = require('./package').version.split('.')
+
 var config = {
   baseUrl: 'https://github.com/atom/electron/releases/download/',
   // Sync minor version of package to minor version of Electron release
-  electron: 'v0.' + require('./package').version.split('.')[1] + '.0',
+  electron: 'v' + versionSegments[0] + '.' + versionSegments[1] + '.0',
   outputPath: path.join(__dirname, 'bin'),
   version: 'v2.15'
 }

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -38,6 +38,7 @@ mkdirp(config.outputPath, function (error) {
 
   request.get({uri: fullUrl, encoding: null}, function (error, response, body) {
     if (error) return handleError(error)
+    if (response.statusCode !== 200) return handleError(Error('Non-200 response (' + response.statusCode + ')'))
     unzip(body, function (error) {
       if (error) return handleError(error)
       if (process.platform !== 'win32') {


### PR DESCRIPTION
Small tweak to use the major and minor version values from the local `package.json` instead of only the minor with a hard-coded `0` for the major.