### PR TITLE
Support overriding URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ This library is used by [spectron](https://github.com/electron/spectron).
 npm install --save-dev electron-chromedriver
 chromedriver -h
 ```
+
+## Custom Mirror
+
+You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables)
+environment variables to use a custom base URL for grabbing ChromeDriver zips.
+
+```sh
+# Electron mirror for China
+ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+
+# Local mirror
+# Example of requested URL: http://localhost:8080/1.2.0/chromedriver-v2.21-darwin-x64.zip
+ELECTRON_MIRROR="http://localhost:8080/"
+```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ chromedriver -h
 ## Custom Mirror
 
 You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables)
-environment variables to use a custom base URL for grabbing ChromeDriver zips.
+environment variables to use a custom base URL for downloading ChromeDriver zips.
 
 ```sh
 # Electron mirror for China

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -5,9 +5,12 @@ var path = require('path')
 var request = require('request')
 
 var versionSegments = require('./package').version.split('.')
+var baseUrl = process.env.NPM_CONFIG_ELECTRON_MIRROR
+  || process.env.ELECTRON_MIRROR
+  || 'https://github.com/electron/electron/releases/download/'
 
 var config = {
-  baseUrl: 'https://github.com/atom/electron/releases/download/',
+  baseUrl: baseUrl,
   // Sync minor version of package to minor version of Electron release
   electron: 'v' + versionSegments[0] + '.' + versionSegments[1] + '.0',
   outputPath: path.join(__dirname, 'bin'),

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -17,11 +17,11 @@ var config = {
   version: 'v2.21'
 }
 
-function handleError (error) {
+function handleError (url, error) {
   if (!error) return
 
   var message = error.message || error
-  console.error('Download failed: ' + message)
+  console.error('Downloading ' + url + ' failed: ' + message)
   process.exit(1)
 }
 
@@ -34,16 +34,16 @@ function unzip (zipped, callback) {
 }
 
 mkdirp(config.outputPath, function (error) {
-  if (error) return handleError(error)
-
   var fileName = 'chromedriver-' + config.version + '-' + process.platform + '-' + process.arch + '.zip'
   var fullUrl = config.baseUrl + config.electron + '/' + fileName
 
+  if (error) return handleError(fullUrl, error)
+
   request.get({uri: fullUrl, encoding: null}, function (error, response, body) {
     if (error) return handleError(error)
-    if (response.statusCode !== 200) return handleError(Error('Non-200 response (' + response.statusCode + ')'))
+    if (response.statusCode !== 200) return handleError(fullUrl, Error('Non-200 response (' + response.statusCode + ')'))
     unzip(body, function (error) {
-      if (error) return handleError(error)
+      if (error) return handleError(fullUrl, error)
       if (process.platform !== 'win32') {
         fs.chmod(path.join(__dirname, 'bin', 'chromedriver'), '755', handleError)
       }

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -45,7 +45,9 @@ mkdirp(config.outputPath, function (error) {
     unzip(body, function (error) {
       if (error) return handleError(fullUrl, error)
       if (process.platform !== 'win32') {
-        fs.chmod(path.join(__dirname, 'bin', 'chromedriver'), '755', handleError)
+        fs.chmod(path.join(__dirname, 'bin', 'chromedriver'), '755', function(error) {
+          if (error) return handleError(fullUrl, error)
+        })
       }
     })
   })

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -7,12 +7,12 @@ var request = require('request')
 var versionSegments = require('./package').version.split('.')
 var baseUrl = process.env.NPM_CONFIG_ELECTRON_MIRROR
   || process.env.ELECTRON_MIRROR
-  || 'https://github.com/electron/electron/releases/download/'
+  || 'https://github.com/electron/electron/releases/download/v'
 
 var config = {
   baseUrl: baseUrl,
   // Sync minor version of package to minor version of Electron release
-  electron: 'v' + versionSegments[0] + '.' + versionSegments[1] + '.0',
+  electron: versionSegments[0] + '.' + versionSegments[1] + '.0',
   outputPath: path.join(__dirname, 'bin'),
   version: 'v2.21'
 }

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -5,9 +5,9 @@ var path = require('path')
 var request = require('request')
 
 var versionSegments = require('./package').version.split('.')
-var baseUrl = process.env.NPM_CONFIG_ELECTRON_MIRROR
-  || process.env.ELECTRON_MIRROR
-  || 'https://github.com/electron/electron/releases/download/v'
+var baseUrl = process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+  process.env.ELECTRON_MIRROR ||
+  'https://github.com/electron/electron/releases/download/v'
 
 var config = {
   baseUrl: baseUrl,
@@ -45,7 +45,7 @@ mkdirp(config.outputPath, function (error) {
     unzip(body, function (error) {
       if (error) return handleError(fullUrl, error)
       if (process.platform !== 'win32') {
-        fs.chmod(path.join(__dirname, 'bin', 'chromedriver'), '755', function(error) {
+        fs.chmod(path.join(__dirname, 'bin', 'chromedriver'), '755', function (error) {
           if (error) return handleError(fullUrl, error)
         })
       }

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -40,7 +40,7 @@ mkdirp(config.outputPath, function (error) {
   if (error) return handleError(fullUrl, error)
 
   request.get({uri: fullUrl, encoding: null}, function (error, response, body) {
-    if (error) return handleError(error)
+    if (error) return handleError(fullUrl, error)
     if (response.statusCode !== 200) return handleError(fullUrl, Error('Non-200 response (' + response.statusCode + ')'))
     unzip(body, function (error) {
       if (error) return handleError(fullUrl, error)


### PR DESCRIPTION
Adds an `ELECTRON_MIRROR` and `NPM_CONFIG_ELECTRON_MIRROR` env var support to customize where chromedriver is downloaded from.

Follows the lead of [electron-download](https://github.com/electron-userland/electron-download/blob/master/readme.md#usage) 🎩 

Closes https://github.com/electron/electron/issues/6303