### PR TITLE
fix: check if chromedriver fails to start correctly

### DIFF
--- a/chromedriver.js
+++ b/chromedriver.js
@@ -13,6 +13,16 @@ var options = {
 
 var chromeDriverProcess = ChildProcess.spawn(command, args, options)
 
+chromeDriverProcess.on('close', function (code) {
+  if (code !== 0) {
+    throw new Error(`chromedriver exit with code ${code}`)
+  }
+})
+
+chromeDriverProcess.on('error', function (error) {
+  throw error
+})
+
 var killChromeDriver = function () {
   try {
     chromeDriverProcess.kill()


### PR DESCRIPTION
I started hitting an issue when testing an Electron application using
Spectron where Spectron's `app.start()` promise will never resolve on a
certain Mac Mini test worker, causing my tests to timeout (see related
linked issue in the commit footer).

The problem ended up being that there was a mysterious `chromedriver`
process running on the Mac Mini, bound to port 9515 (the default port).
The following steps led to the problem:

- Spectron ran `electron-chromedriver` using the default port
- `electron-chromedriver` spawned `chromedriver` on 9515, but it
reported success even though `chromedriver` printed the following error
in the background:

```
Starting ChromeDriver 2.27 (44a803957cb27610c38f7e859016ac257959aeb5) on port 9515
Only local connections are allowed.
[0.004][SEVERE]: bind() returned an error, errno=48: Address already in use
[0.005][SEVERE]: bind() returned an error, errno=48: Address already in use
Port not available. Exiting...
```

- Spectron sent a request to `http://127.0.0.1:9515/wd/hub/status` to
check if `chromedriver` was started. The mysterious `chromedriver`
process would respond to that, so Spectron happily continued

- At some point in the future, Spectron would send more HTTP requests to
the incorrect `chromedriver` server, causing some weird behaviour, and
eventually making everything hang

As a "fix", this commit checks that `chromedriver` didn't fail to
initialize, so people can at least have a better chance to understand
what went wrong on the first place.

See: https://github.com/electron/spectron/issues/312
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>