### PR TITLE
Update to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {


### PR DESCRIPTION
Electron 3.0.0. is out, please update the version of electron-chromedriver too. Chromedriver version stays at 2.36 so the test should pass without change. Thanks.