### PR TITLE
feat: update for 4-0-x release line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "3.0.0",
+  "version": "4.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "3.0.0",
+  "version": "4.0.0-beta.1",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {

--- a/test/chromedriver-test.js
+++ b/test/chromedriver-test.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const ChildProcess = require('child_process')
 const path = require('path')
+const { version } = require('../package')
 
 const describe = global.describe
 const it = global.it
@@ -20,7 +21,11 @@ describe('chromedriver binary', function () {
     chromeDriver.stderr.on('data', data => output += data)
 
     chromeDriver.on('close', () => {
-      assert.equal(output.indexOf('ChromeDriver 2.36'), 0, `Unexpected version: ${output}`)
+      if (version.startsWith('3')) {
+        assert.equal(output.indexOf('ChromeDriver 2.36'), 0, `Unexpected version: ${output}`)
+      } else if (version.startsWith('4')) {
+        assert.equal(output.indexOf('ChromeDriver 69.0.3497.106'), 0, `Unexpected version: ${output}`)
+      }
     })
 
     chromeDriver.on('error', done)


### PR DESCRIPTION
Updates version for compatibility with `4-0-x` release line to allow users access to Chromedriver `2.40`.

/cc @jkleinsc 