### PR TITLE
feat: update for 3-1-x release line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "4.0.0-beta.1",
+  "version": "3.1.3",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {


### PR DESCRIPTION
Atom needs an `electron-chromedriver` release in the 3.1.x line so that we can upgrade Electron 3.1.x.  Hopefully this is as simple as the change needs to be!  Let me know if there's anything else I should do.