### PR TITLE
chore: bump version to stable release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {


### PR DESCRIPTION
I'm not sure if there's anything else that needs to be done here (the test passes fine), so let me know if there's anything I can help with to start using `electron-chromedriver` and `spectron` with Electron 4 stable releases.