### PR TITLE
chore: add support for Electron 5 Beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "4.0.0-beta.1",
+  "version": "5.0.0-beta.1",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {


### PR DESCRIPTION
We should land https://github.com/electron/chromedriver/pull/39 first