### PR TITLE
chore: add support for Electron v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {

--- a/test/chromedriver-test.js
+++ b/test/chromedriver-test.js
@@ -10,7 +10,7 @@ const versions = {
   3: 'ChromeDriver 2.36',
   4: 'ChromeDriver 2.40.613160',
   5: 'ChromeDriver 2.45',
-  6: 'ChromeDriver 76.0.3783.1'
+  6: 'ChromeDriver 76.0.3809.88'
 }
 
 describe('chromedriver binary', function () {


### PR DESCRIPTION
Update for Electron stable `v6.0.0`.

cc @jkleinsc 