### PR TITLE
feat: Download the electron version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@
 Simple node module to download the [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver)
 version for [Electron](http://electron.atom.io).
 
-The major version of this library tracks the major version of the Electron
-versions released. So if you are using Electron `2.0.x` you would want to use
-an `electron-chromedriver` dependency of `~2.0.0` in your `package.json` file.
+By default, this library will use your `electron` version to figure out which
+version of Chromedriver to download. If that fails, the major version of this
+library tracks the major version of the Electron versions released. So if you
+are using Electron `2.0.x` you would want to use an `electron-chromedriver`
+dependency of `~2.0.0` in your `package.json` file.
 
 This library is used by [spectron](https://github.com/electron/spectron).
 

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -2,7 +2,15 @@ const fs = require('fs')
 const path = require('path')
 const electronDownload = require('electron-download')
 const extractZip = require('extract-zip')
-const versionToDownload = require('./package').version
+
+function getVersion () {
+  const pack = require('./package') || {}
+  const dependencies = pack.dependencies
+  const devDependencies = pack.devDependencies
+  const allDependencies = { ...dependencies, ...devDependencies }
+
+  return allDependencies['electron'] || pack.version
+}
 
 function download (version, callback) {
   electronDownload({
@@ -26,6 +34,8 @@ function processDownload (err, zipPath) {
     }
   })
 }
+
+const versionToDownload = getVersion()
 
 download(versionToDownload, (err, zipPath) => {
   if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-chromedriver",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Electron ChromeDriver",
   "repository": "https://github.com/electron/chromedriver",
   "bin": {


### PR DESCRIPTION
Hey friends! This PR does two things:

:one: We currently hard-code downloading `chromedriver` for whatever version _this_ package is at. Let's change that to whatever the `electron` version is at, with this package's own version being used as the fallback.

:two: Bump the version to v7