### PR TITLE
feat: add support for ELECTRON_CHROMEDRIVER_CUSTOM_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
 # Example of requested URL: http://localhost:8080/1.2.0/chromedriver-v2.21-darwin-x64.zip
 ELECTRON_MIRROR="http://localhost:8080/"
 ```
+
+The other environment variables supported by [electron-download](https://www.npmjs.com/package/electron-download)
+(`ELECTRON_CUSTOM_DIR`, `ELECTRON_CUSTOM_FILENAME`) are similarly supported.
+
+## Custom Version
+
+By default, this library will download the version of ChromeDriver matching the
+version of this library, with fallback to patch version 0 of the same major and
+minor version.
+
+You can download a specific version of ChromeDriver instead by setting either an
+environment variable or a `.npmrc` config value named `ELECTRON_CHROMEDRIVER_CUSTOM_VERSION`.
+
+You can use this on its own or in combination with the Custom Mirror options.
+`ELECTRON_CUSTOM_DIR` and `ELECTRON_CUSTOM_FILENAME` will take precedence over
+the dir/filename that would be implied by `ELECTRON_CHROMEDRIVER_CUSTOM_VERSION`.
+
+```sh
+# Example of requested URL: https://example.com/builds/7.1.8/no-media-codecs/chromedriver-v7.1.8-win32-x64.zip
+ELECTRON_MIRROR="https://example.com/builds/"
+ELECTRON_CUSTOM_DIR="7.1.8/no-media-codecs"
+ELECTRON_CHROMEDRIVER_CUSTOM_VERSION="7.1.8"
+```

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -32,10 +32,10 @@ const parts = primaryVersion.split('.')
 let fallbackVersion = `${parts[0]}.${parts[1]}.0`
 
 const versionEnvVar = (
-  process.env[`NPM_CONFIG_ELECTRON_CHROMEDRIVER_CUSTOM_VERSION`] ||
-  process.env[`npm_config_electron_chromedriver_custom_version`] ||
-  process.env[`npm_package_config_electron_chromedriver_custom_version`] ||
-  process.env[`ELECTRON_CHROMEDRIVER_CUSTOM_VERSION}`]
+  process.env['NPM_CONFIG_ELECTRON_CHROMEDRIVER_CUSTOM_VERSION'] ||
+  process.env['npm_config_electron_chromedriver_custom_version'] ||
+  process.env['npm_package_config_electron_chromedriver_custom_version'] ||
+  process.env['ELECTRON_CHROMEDRIVER_CUSTOM_VERSION']
 )
 
 if (versionEnvVar != null) {

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const electronDownload = require('electron-download')
 const extractZip = require('extract-zip')
-const versionToDownload = require('./package').version
+const thisPackageVersion = require('./package').version
 
 function download (version, callback) {
   electronDownload({
@@ -27,11 +27,25 @@ function processDownload (err, zipPath) {
   })
 }
 
-download(versionToDownload, (err, zipPath) => {
-  if (err) {
-    const parts = versionToDownload.split('.')
-    const baseVersion = `${parts[0]}.${parts[1]}.0`
-    download(baseVersion, processDownload)
+let primaryVersion = thisPackageVersion
+const parts = primaryVersion.split('.')
+let fallbackVersion = `${parts[0]}.${parts[1]}.0`
+
+const versionEnvVar = (
+  process.env[`NPM_CONFIG_ELECTRON_CHROMEDRIVER_CUSTOM_VERSION`] ||
+  process.env[`npm_config_electron_chromedriver_custom_version`] ||
+  process.env[`npm_package_config_electron_chromedriver_custom_version`] ||
+  process.env[`ELECTRON_CHROMEDRIVER_CUSTOM_VERSION}`]
+)
+
+if (versionEnvVar != null) {
+  primaryVersion = versionEnvVar
+  fallbackVersion = null
+}
+
+download(primaryVersion, (err, zipPath) => {
+  if (err && fallbackVersion) {
+    download(fallbackVersion, processDownload)
   } else {
     processDownload(err, zipPath)
   }


### PR DESCRIPTION
#### Summary

This PR adds support and documentation for a `ELECTRON_CHROMEDRIVER_CUSTOM_VERSION` environment variable/`.npmrc` variable. If set, it will override the library's existing default behavior of using the library version.

#### Motivation

My team publishes an Electron app that is built against internally-built Electron binaries, and we wanted to be able to test against correspondingly built chromedriver binaries. We wanted to avoid the use of `ELECTRON_CUSTOM_FILENAME` for this, since the filenames encode platform information and we'd rather keep as much of our build config as possible platform-agnostic. However, the default filename also encodes version information from this library, which mismatches the version produced by the custom build we set in `ELECTRON_CUSTOM_DIR`. The example included in the `README.md` update here is an anonymized version of our team's desired use case.

#### Implementation notes

#49 would address this for us, but I wasn't sure how to reasonably address the comments there (it didn't seem thrilling to add a `peerDependency` on electron to be able to read its `package.json` version sanely, nor did it seem thrilling to try reading the various types of lockfiles that might exist), so I went with this more manual option instead.

For the specific name of the new config value and the precedence order for checking the assorted env var options, I tried to follow the example of what electron-download does for the similar custom mirror/dir/filename variables (https://github.com/electron/get/blob/master/src/artifact-utils.ts#L27).

The custom version logic intentionally avoids the existing fallback mechanism to x.y.0 used with the default version logic; my expectation is that if someone is setting a custom version, they presumably care to be using *exactly* the version they say they want to use. It leaves the fallback logic as-is when using the old default-version behavior.