### PR TITLE
chore: set @wg-releases as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This Repo is an AOR of the Releases Working Group
+* @electron/wg-releases


### PR DESCRIPTION
What it says on the tin.

cc @jkleinsc @electron/wg-releases 