### PR TITLE
fix: install npm_config_platform=win32

### DIFF
--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -20,7 +20,7 @@ async function attemptDownload (version) {
     const targetFolder = path.join(__dirname, 'bin')
     const zipPath = await download(version)
     await extractZip(zipPath, { dir: targetFolder })
-    const platform = process.env.npm_config_platform || process.platform;
+    const platform = process.env.npm_config_platform || process.platform
     if (platform !== 'win32') {
       await fs.chmod(path.join(targetFolder, 'chromedriver'), 0o755)
     }

--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -20,7 +20,8 @@ async function attemptDownload (version) {
     const targetFolder = path.join(__dirname, 'bin')
     const zipPath = await download(version)
     await extractZip(zipPath, { dir: targetFolder })
-    if (process.platform !== 'win32') {
+    const platform = process.env.npm_config_platform || process.platform;
+    if (platform !== 'win32') {
       await fs.chmod(path.join(targetFolder, 'chromedriver'), 0o755)
     }
   } catch (err) {


### PR DESCRIPTION
Closes #60 

**Summary**
This PR fixes an issue when trying to install `electron` on a linux machine with environment variable `npm_config_platform=win32`.

**Motivation**
There is support for building electron apps on linux for windows. The `npm_config_platform` is an environment variable that is usually used to instruct npm packages about the platform for which custom or pre-built binaries should be downloaded.   

For example, running: `npm_config_platform=win32 npm i electron-chromedriver` should download the Windows chromedriver.exe even when I run it on a linux machine. This is currently broken and attempting to run it on linux fails with an error.  
  
There is not much use in downloading the Windows chromedriver on linux. However, if you have a native dependency like [`sharp`](https://github.com/lovell/sharp) and try to install all packages with `npm_config_platform=win32 npm i` in order to create a Windows build, you still get the same error from `electron-chromedriver` package.
