### PR TITLE
fix: use same settings for force and cacheRoot as electron

### DIFF
--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -8,6 +8,8 @@ function download (version) {
   return downloadArtifact({
     version,
     artifactName: 'chromedriver',
+    force: process.env.force_no_cache === 'true',
+    cacheRoot: process.env.electron_config_cache,
     platform: process.env.npm_config_platform,
     arch: process.env.npm_config_arch,
     rejectUnauthorized: process.env.npm_config_strict_ssl === 'true',


### PR DESCRIPTION
Found this inconsistency between `electron` and `electron-chromedriver` while investigating https://github.com/electron/get/issues/160

Current `master` (does not set `cacheRoot`, fallback behaviour due to `undefined` cache):

```
$ electron_config_cache=/opt/electron/cache DEBUG=* node ./download-chromedriver.js 
  @electron/get:index No platform found, defaulting to the host platform +0ms
  @electron/get:index No arch found, defaulting to the host arch +1ms
  @electron/get:index Checking the cache (undefined) for chromedriver-v11.0.0-linux-x64.zip (https://github.com/electron/electron/releases/download/v11.0.0/chromedriver-v11.0.0-linux-x64.zip) +1ms
  @electron/get:index Cache hit +2ms
  extract-zip creating target directory /home/shiftkey/src/chromedriver/bin +0ms
  ...
```


This PR (sets `cacheRoot` to `electron_config_cache` if defined):

```
$ electron_config_cache=/opt/electron/cache DEBUG=* node ./download-chromedriver.js
  @electron/get:index No platform found, defaulting to the host platform +0ms
  @electron/get:index No arch found, defaulting to the host arch +0ms
  @electron/get:index Checking the cache (/opt/electron/cache) for chromedriver-v11.0.0-linux-x64.zip (https://github.com/electron/electron/releases/download/v11.0.0/chromedriver-v11.0.0-linux-x64.zip) +1ms
  @electron/get:index Cache miss +2ms
  @electron/get:index Downloading https://github.com/electron/electron/releases/download/v11.0.0/chromedriver-v11.0.0-linux-x64.zip to /tmp/electron-download-1dwK65/chromedriver-v11.0.0-linux-x64.zip with options: undefined +15ms
  @electron/get:index Checking the cache (/opt/electron/cache) for SHASUMS256.txt (https://github.com/electron/electron/releases/download/v11.0.0/SHASUMS256.txt) +3s
  @electron/get:index Cache miss +1ms
  @electron/get:index Downloading https://github.com/electron/electron/releases/download/v11.0.0/SHASUMS256.txt to /tmp/electron-download-Eg43p6/SHASUMS256.txt with options: undefined +0ms
  @electron/get:cache Moving /tmp/electron-download-Eg43p6/SHASUMS256.txt to /opt/electron/cache/httpsgithub.comelectronelectronreleasesdownloadv11.0.0SHASUMS256.txt/SHASUMS256.txt +0ms
  sumchecker Reading "/opt/electron/cache/httpsgithub.comelectronelectronreleasesdownloadv11.0.0SHASUMS256.txt/SHASUMS256.txt (binary mode: false)" +0ms
  ...
```