### PR TITLE
fix: don't throw error when code is null

### DIFF
--- a/chromedriver.js
+++ b/chromedriver.js
@@ -14,7 +14,7 @@ const options = {
 const chromeDriverProcess = ChildProcess.spawn(command, args, options)
 
 chromeDriverProcess.on('close', code => {
-  if (code !== 0) {
+  if (code !== null && code !== 0) {
     throw new Error(`Chromedriver exited with error code: ${code}`)
   }
 })


### PR DESCRIPTION
Even though the docs don't seem to suggest that this event's `code` argument can be null. In practice it has the same characteristics as the `"exit"` event.

This package shouldn't throw if the function `killChromeDriver` was called.