### PR TITLE
chore: update hardcoded master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Electron ChromeDriver
 
-[![Linux and Mac Build Status](https://circleci.com/gh/electron/chromedriver/tree/master.svg?style=shield)](https://circleci.com/gh/electron/chromedriver/tree/master)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/43safb37jdlaeviw/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/chromedriver/branch/master)
+[![Linux and Mac Build Status](https://circleci.com/gh/electron/chromedriver/tree/main.svg?style=shield)](https://circleci.com/gh/electron/chromedriver/tree/main)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/43safb37jdlaeviw/branch/main?svg=true)](https://ci.appveyor.com/project/electron-bot/chromedriver/branch/main)
 <br>
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 [![devDependencies:?](https://img.shields.io/david/electron/chromedriver.svg)](https://david-dm.org/electron/chromedriver)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ skip_tags: true
 
 branches:
   only:
-    - master
+    - main
 
 environment:
   nodejs_version: "10"


### PR DESCRIPTION
This PR changes a few instances (such as AppVeyor) where we were hardcoding the default branch as "master". It should be merged when the branch name is changed to `main`!