### PR TITLE
chore: add release update action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release For New Electron Version
+
+on:
+  workflow_dispatch:
+    inputs:
+        version:
+          description: 'version'
+          required: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set Git Credentials
+        run: |
+          git config user.name electron-bot
+          git config user.email electron@github.com
+      - name: Update Version
+        run: node script/update-version.js ${{ github.event.inputs.version }}
+      - name: Push Update Commit
+        run: |
+          git add .
+          git commit -m "chore: update version to ${{ github.event.inputs.version }}"
+          git push origin main
+      - name: Push New Tag
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
+      - name: Create Release
+        run: |
+          gh release create ${{ github.event.inputs.version }} -t ${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
           description: 'version'
           required: true
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -30,5 +33,3 @@ jobs:
       - name: Create Release
         run: |
           gh release create ${{ github.event.inputs.version }} -t ${{ github.event.inputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "mocha": "^8.3.0",
+        "semver": "^7.3.7",
         "standard": "^13.1.0"
       },
       "engines": {
@@ -577,6 +578,15 @@
       },
       "engines": {
         "node": ">=4.8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/debug": {
@@ -1711,21 +1721,6 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/global-tunnel-ng": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
@@ -2329,7 +2324,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2559,6 +2554,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -3258,12 +3262,18 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true,
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "devOptional": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -3880,7 +3890,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -4438,6 +4448,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "debug": {
@@ -5321,17 +5339,6 @@
         "roarr": "^2.15.3",
         "semver": "^7.3.2",
         "serialize-error": "^7.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "global-tunnel-ng": {
@@ -5813,7 +5820,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5988,6 +5995,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -6528,10 +6543,13 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "devOptional": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -7021,7 +7039,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "devOptional": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       },
       "devDependencies": {
         "mocha": "^8.3.0",
-        "semver": "^7.3.7",
         "standard": "^13.1.0"
       },
       "engines": {
@@ -2324,7 +2323,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3265,7 +3264,7 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3890,7 +3889,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -5820,7 +5819,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -6546,7 +6545,7 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -7039,7 +7038,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "optional": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "mocha": "^8.3.0",
+    "semver": "^7.3.7",
     "standard": "^13.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "mocha": "^8.3.0",
-    "semver": "^7.3.7",
     "standard": "^13.1.0"
   }
 }

--- a/script/update-version.js
+++ b/script/update-version.js
@@ -1,0 +1,37 @@
+const { promises: fs } = require('fs')
+const path = require('path')
+
+const versionFormat = /^(\d+\.)(\d+\.)(\d+)$/
+
+const normalizeVersion = (version = '') => {
+  return version.startsWith('v') ? version.slice(1) : version
+}
+
+async function updateVersion () {
+  const version = normalizeVersion(process.argv[2])
+  if (!versionFormat.test(version)) {
+    console.error(`Invalid version ${version}`)
+    process.exit(1)
+  }
+
+  const PJ_PATH = path.join(__dirname, '..', 'package.json')
+  const pj = require(PJ_PATH)
+
+  const PJLOCK_PATH = path.join(__dirname, '..', 'package-lock.json')
+  const pjLock = require(PJLOCK_PATH)
+
+  try {
+    pj.version = version
+    await fs.writeFile(PJ_PATH, JSON.stringify(pj, null, 2))
+    console.log(`Updated package.json version to ${version}`)
+
+    pjLock.version = version
+    await fs.writeFile(PJLOCK_PATH, JSON.stringify(pjLock, null, 2))
+    console.log(`Updated package-lock.json version to ${version}`)
+  } catch (e) {
+    console.error('Failed to update chromedriver version: ', e)
+    process.exit(1)
+  }
+}
+
+updateVersion()


### PR DESCRIPTION
This partially automates the process of releasing new versions of chromedriver when new major releases to Electron occur.

We'll also need to add something like this to the Electron repo itself.

```yml
name: Trigger Major Release Dependency Updates

on:
  release:
    types: [published]

jobs:
  notify:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - name: Trigger New chromedriver Release
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh api /repos/:owner/chromedriver/actions/workflows/release.yml/dispatches \
   --input - <<< '{"ref":"main","inputs":{"version":"${{ github.event.release.tag_name }}"}}'
 ```