### PR TITLE
chore: remove semicolon to fix linting

### DIFF
--- a/script/update-version.js
+++ b/script/update-version.js
@@ -11,7 +11,7 @@ async function updateVersion () {
   const version = normalizeVersion(process.argv[2])
   if (!versionFormat.test(version)) {
     console.error(`Unsupported version ${version} - only major, minor, and patch releases are currently supported`)
-    return;
+    return
   }
 
   const PJ_PATH = path.join(__dirname, '..', 'package.json')


### PR DESCRIPTION
Test is failing on `main` at the moment due to a rogue semicolon.