### PR TITLE
ci: bump Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - test
   test-mac:
     macos:
-      xcode: "13.3.0"
+      xcode: "14.0.0"
     parameters:
       node-version:
         description: Node.js version to install


### PR DESCRIPTION
The current version is deprecated on CircleCI and will be sunset in the next couple of months.