### PR TITLE
build: bump CFA publish step timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - run:
           name: CFA Publish
           command: node script/publish.js
+          no_output_timeout: 30m
 
 workflows:
   test_and_release:


### PR DESCRIPTION
We've missed a few of the automated releases by not providing the CFA token in a timely enough manner, as unfortunately the stable builds usually finish at the non-ideal time of lunch time PST. Let's bump the window for providing the token to give ourselves a better chance.