### PR TITLE
build: switch from .npmignore to files field in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.npmignore
-.travis.yml
-appveyor.yml
-test
-bin

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "chromedriver": "./chromedriver.js"
   },
+  "files": [
+    "./chromedriver.js",
+    "./download-chromedriver.js"
+  ],
   "scripts": {
     "install": "node ./download-chromedriver.js",
     "lint": "standard --fix",


### PR DESCRIPTION
The published package is including unnecessary files at the moment, and we've been migrating to using the `"files"` field in `package.json` instead of `.npmignore`.