### PR TITLE
ci: fix test job on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: electronjs/node@1.1.0
+  node: electronjs/node@1.2.0
 
 jobs:
   release:
@@ -38,8 +38,7 @@ workflows:
       - node/test:
           name: test-<< matrix.executor >>-<< matrix.node-version >>
           pkg-manager: npm
-          checkout-steps:
-            - checkout
+          post-node-js-install-steps:
             - when:
                 condition: << pipeline.git.tag >>
                 steps:


### PR DESCRIPTION
Forgot that with the `electronjs/node` orb, `node/test` goes: checkout -> install Node.js -> install packages -> test. So we need to run the steps to set the Electron version to test after installing Node.js but before installing packages.