### PR TITLE
ci: bump electronjs/node orb version to fix cache issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: electronjs/node@1.4.0
+  node: electronjs/node@1.4.1
 
 jobs:
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: electronjs/node@1.2.0
+  node: electronjs/node@1.4.0
 
 jobs:
   release:
@@ -37,6 +37,7 @@ workflows:
     jobs:
       - node/test:
           name: test-<< matrix.executor >>-<< matrix.node-version >>
+          cache-version: v2
           pkg-manager: npm
           post-node-js-install-steps:
             - when:
@@ -62,9 +63,7 @@ workflows:
                 - node/macos
                 - node/windows
               node-version:
-                # Don't bump above 20.2.0 until CircleCI updates
-                # their Windows image to pick up newer nvm-windows
-                - 20.2.0
+                - 20.5.1
                 - 18.17.0
                 - 16.20.1
                 - 14.21.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ workflows:
     jobs:
       - node/test:
           name: test-<< matrix.executor >>-<< matrix.node-version >>
-          cache-version: v2
           pkg-manager: npm
           post-node-js-install-steps:
             - when:


### PR DESCRIPTION
Fixes detecting of failed Node.js installs with `nvm-windows` and bumps the cache version to clear out a corrupted cache as a result of not detecting those failed installs. The cache key does not need to be explicitly bumped because the newest version of the orb changed the cache key format so it effectively changes the cache key.

Also bumps the Node.js v20 version and clears a note regarding that, now that the issue has been fixed upstream.

Refs https://app.circleci.com/pipelines/github/electron/chromedriver/209/workflows/2342bf81-1ee5-49fc-be87-b2901f0431ea/jobs/1079