### PR TITLE
ci: add write permission to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
   create_new_version:
     runs-on: ubuntu-latest
     needs: smoke_test
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       # Tag here, the CircleCI workflow will trigger on the new tag and do the CFA publish


### PR DESCRIPTION
The default permissions for `GITHUB_TOKEN` appear to have changed on this repo in the past 48 hours, and we weren't explicitly setting write perms before.