### PR TITLE
test: modernize smoke test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,8 @@
       },
       "devDependencies": {
         "@continuous-auth/client": "^2.2.2",
-        "@electron/fiddle-core": "^1.3.0",
+        "@electron/fiddle-core": "^1.3.3",
         "mocha": "^10.1.0",
-        "semver": "^7.3.8",
         "standard": "^13.1.0"
       },
       "engines": {
@@ -57,9 +56,9 @@
       }
     },
     "node_modules/@electron/fiddle-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@electron/fiddle-core/-/fiddle-core-1.3.0.tgz",
-      "integrity": "sha512-RlH4j0RtcRHMVQCaiC/xS8UmvmmgTqCJI8Iw+GIUTswzA7WrXRPCTX+izvb2NiBmpf0Ll/+GPuQ1VtV9v3P7pA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/fiddle-core/-/fiddle-core-1.3.3.tgz",
+      "integrity": "sha512-aBUN+jsNsLo+Ywfl0wQy2TRRGC8TvLF42Lt9zOdrzGgT7vzDNiFvr7+UiRVvC5inGR0XgeTmZpwaS6CnT6ZPWA==",
       "dev": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -69,11 +68,24 @@
         "fs-extra": "^10.0.0",
         "getos": "^3.2.1",
         "node-fetch": "^2.6.1",
+        "rimraf": "^4.4.1",
         "semver": "^7.3.5",
         "simple-git": "^3.5.0"
       },
       "bin": {
         "fiddle-core": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@electron/fiddle-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/fiddle-core/node_modules/fs-extra": {
@@ -90,6 +102,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@electron/fiddle-core/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@electron/fiddle-core/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -100,6 +130,39 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/fiddle-core/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/fiddle-core/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@electron/fiddle-core/node_modules/universalify": {
@@ -2557,6 +2620,15 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -3014,6 +3086,40 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -4202,9 +4308,9 @@
       }
     },
     "@electron/fiddle-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@electron/fiddle-core/-/fiddle-core-1.3.0.tgz",
-      "integrity": "sha512-RlH4j0RtcRHMVQCaiC/xS8UmvmmgTqCJI8Iw+GIUTswzA7WrXRPCTX+izvb2NiBmpf0Ll/+GPuQ1VtV9v3P7pA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/fiddle-core/-/fiddle-core-1.3.3.tgz",
+      "integrity": "sha512-aBUN+jsNsLo+Ywfl0wQy2TRRGC8TvLF42Lt9zOdrzGgT7vzDNiFvr7+UiRVvC5inGR0XgeTmZpwaS6CnT6ZPWA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -4214,10 +4320,20 @@
         "fs-extra": "^10.0.0",
         "getos": "^3.2.1",
         "node-fetch": "^2.6.1",
+        "rimraf": "^4.4.1",
         "semver": "^7.3.5",
         "simple-git": "^3.5.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -4229,6 +4345,18 @@
             "universalify": "^2.0.0"
           }
         },
+        "glob": {
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^8.0.2",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
+        },
         "jsonfile": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4237,6 +4365,24 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+          "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+          "dev": true,
+          "requires": {
+            "glob": "^9.2.0"
           }
         },
         "universalify": {
@@ -6148,6 +6294,12 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true
+    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -6497,6 +6649,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-scurry": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
+      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+          "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+          "dev": true
+        }
+      }
     },
     "pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
   },
   "devDependencies": {
     "@continuous-auth/client": "^2.2.2",
-    "@electron/fiddle-core": "^1.3.0",
+    "@electron/fiddle-core": "^1.3.3",
     "mocha": "^10.1.0",
-    "semver": "^7.3.8",
     "standard": "^13.1.0"
   }
 }

--- a/test/chromedriver-test.js
+++ b/test/chromedriver-test.js
@@ -11,13 +11,18 @@ function outputHasExpectedVersion (output, version) {
   return output.toString().includes(version)
 }
 
-describe('chromedriver binary', () => {
-  it('launches successfully', async () => {
+describe('chromedriver binary', function () {
+  this.timeout(10000)
+
+  it('launches successfully', async function () {
+    // Skip when this package is not properly configured for an Electron release
+    if (releaseVersion === '0.0.0-development') {
+      this.skip()
+    }
+
     // Get the expected release information for this release
     const versions = await ElectronVersions.create()
     const expectedInfo = versions.getReleaseInfo(releaseVersion)
-
-    assert.notStrictEqual(expectedInfo, undefined, `Could not find Electron release information for release ${releaseVersion}`)
 
     const { chrome: expectedChromeVersion } = expectedInfo
 
@@ -32,4 +37,4 @@ describe('chromedriver binary', () => {
       `Did not find expected Chromium version: ${expectedChromeVersion}\nstdout:\n---\n${stdout}\n---\nstderr:\n${stderr}\n---`
     )
   })
-}).timeout(10000)
+})

--- a/test/chromedriver-test.js
+++ b/test/chromedriver-test.js
@@ -1,42 +1,35 @@
 const assert = require('assert')
-const ChildProcess = require('child_process')
+const { spawnSync } = require('child_process')
 const path = require('path')
-const { version } = require('../package')
+const { version: releaseVersion } = require('../package')
+const { ElectronVersions } = require('@electron/fiddle-core')
 
 const describe = global.describe
 const it = global.it
 
-const versions = {
-  3: 'ChromeDriver 2.36',
-  4: 'ChromeDriver 2.40.613160',
-  5: 'ChromeDriver 2.45',
-  6: 'ChromeDriver 76.0.3809.88'
+function outputHasExpectedVersion (output, version) {
+  return output.toString().includes(version)
 }
 
-describe('chromedriver binary', function () {
-  this.timeout(10000)
+describe('chromedriver binary', () => {
+  it('launches successfully', async () => {
+    // Get the expected release information for this release
+    const versions = await ElectronVersions.create()
+    const expectedInfo = versions.getReleaseInfo(releaseVersion)
 
-  it('launches successfully', done => {
-    const args = [
+    assert.notStrictEqual(expectedInfo, undefined, `Could not find Electron release information for release ${releaseVersion}`)
+
+    const { chrome: expectedChromeVersion } = expectedInfo
+
+    // Invoke chormedriver with the flag to output the version
+    const { stdout, stderr } = spawnSync(process.execPath, [
       path.join(__dirname, '..', 'chromedriver.js'),
       '-v'
-    ]
-    const chromeDriver = ChildProcess.spawn(process.execPath, args)
+    ])
 
-    let output = ''
-    chromeDriver.stdout.on('data', data => { output += data })
-    chromeDriver.stderr.on('data', data => { output += data })
-
-    chromeDriver.on('close', () => {
-      for (const v in versions) {
-        if (version.startsWith(v)) {
-          const idx = output.indexOf(versions[v])
-          assert.strictEqual(idx, 0, `Unexpected version: ${output}`)
-        }
-      }
-    })
-
-    chromeDriver.on('error', done)
-    chromeDriver.on('close', () => done())
+    assert(
+      outputHasExpectedVersion(stdout, expectedChromeVersion) || outputHasExpectedVersion(stderr, expectedChromeVersion),
+      `Did not find expected Chromium version: ${expectedChromeVersion}\nstdout:\n---\n${stdout}\n---\nstderr:\n${stderr}\n---`
+    )
   })
-})
+}).timeout(10000)


### PR DESCRIPTION
This PR modernizes the smoke test in this repo.

* The smoke test was updated to use `@electron/fiddle-core` to map the current version of this package to the matching Chromium release, which is what the `-v` (version) flag outputs
* I noticed that the `semver` dev dep isn't used anywhere, so I took the opportunity to remove it