### PR TITLE
ci: add linux deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,17 @@ workflows:
           pkg-manager: npm
           post-node-js-install-steps:
             - when:
+                condition:
+                  equal: [node/linux, << matrix.executor >>]
+                steps:
+                  - run:
+                      name: Linux specific setup
+                      command: |
+                        sudo apt-get update
+                        sudo apt-get install -y \
+                          --no-install-recommends \
+                          libnss3
+            - when:
                 condition: << pipeline.git.tag >>
                 steps:
                   - run:


### PR DESCRIPTION
Linux CI seems to fail due to missing system dependencies required to load chromedriver, which are added in this PR.