### PR TITLE
ci: timeout release job after 1 hour

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Check NPM Credentials
         run: npm whoami
       - name: CFA Publish
+        timeout-minutes: 60
         env:
           CFA_PROJECT_ID: ${{ secrets.CFA_PROJECT_ID }}
           CFA_SECRET: ${{ secrets.CFA_SECRET }}


### PR DESCRIPTION
The GH token acquired is only good for 1 hour, and if a maintainer provides a CFA token after that time we end up with the npm publish going through but none of the follow-up steps on GitHub (creating the release).